### PR TITLE
Wrapped content related to ranked matches

### DIFF
--- a/Grunt/Grunt/Core/HaloInfiniteClient.cs
+++ b/Grunt/Grunt/Core/HaloInfiniteClient.cs
@@ -2683,6 +2683,24 @@ namespace Grunt.Core
             }
         }
 
+        public async Task<PlayerSkillResultValue> SkillGetMatchPlayerResult(string matchId, string playerId)
+        {
+            var response = await ExecuteAPIRequest($"https://skill.svc.halowaypoint.com:443/hi/matches/{matchId}/skill?players={playerId}",
+                                   HttpMethod.Get,
+                                   true,
+                                   true,
+                                   GlobalConstants.HALO_WAYPOINT_USER_AGENT);
+
+            if (!string.IsNullOrEmpty(response))
+            {
+                return JsonConvert.DeserializeObject<PlayerSkillResultValue>(response);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         //TODO: This function requires manual invtervention/checks.
         public async Task<string> SkillGetPlaylistCsr(string playlistId)
         {

--- a/Grunt/Grunt/Models/HaloInfinite/Counterfactuals.cs
+++ b/Grunt/Grunt/Models/HaloInfinite/Counterfactuals.cs
@@ -1,0 +1,8 @@
+﻿namespace Grunt.Models.HaloInfinite
+{
+    public class Counterfactuals
+    {
+        public KillDeathStats SelfCounterfactuals { get; set; }
+        public TierCounterfactuals TierCounterfactuals { get; set; }
+    }
+}

--- a/Grunt/Grunt/Models/HaloInfinite/KillDeathStats.cs
+++ b/Grunt/Grunt/Models/HaloInfinite/KillDeathStats.cs
@@ -1,0 +1,8 @@
+﻿namespace Grunt.Models.HaloInfinite
+{
+    public class KillDeathStats
+    {
+        public double Kills { get; set; }
+        public double Deaths { get; set; }
+    }
+}

--- a/Grunt/Grunt/Models/HaloInfinite/MatchCsr.cs
+++ b/Grunt/Grunt/Models/HaloInfinite/MatchCsr.cs
@@ -1,0 +1,14 @@
+﻿namespace Grunt.Models.HaloInfinite
+{
+    public class MatchCsr
+    {
+        public int Value { get; set; }
+        public int MeasurementMatchesRemaining { get; set; }
+        public string Tier { get; set; }
+        public int TierStart { get; set; }
+        public int SubTier { get; set; }
+        public string NextTier { get; set; }
+        public int NextTierStart { get; set; }
+        public int InitialMeasurementMatches { get; set; }
+    }
+}

--- a/Grunt/Grunt/Models/HaloInfinite/PerformanceValue.cs
+++ b/Grunt/Grunt/Models/HaloInfinite/PerformanceValue.cs
@@ -1,0 +1,9 @@
+﻿namespace Grunt.Models.HaloInfinite
+{
+    public class PerformanceValue
+    {
+        public int Count { get; set; }
+        public double Expected { get; set; }
+        public double StdDev { get; set; }
+    }
+}

--- a/Grunt/Grunt/Models/HaloInfinite/PlayerSkillResult.cs
+++ b/Grunt/Grunt/Models/HaloInfinite/PlayerSkillResult.cs
@@ -1,0 +1,9 @@
+﻿namespace Grunt.Models.HaloInfinite
+{
+    public class PlayerSkillResult
+    {
+        public string Id { get; set; }
+        public int ResultCode { get; set; }
+        public Result Result { get; set; }
+    }
+}

--- a/Grunt/Grunt/Models/HaloInfinite/PlayerSkillResultValue.cs
+++ b/Grunt/Grunt/Models/HaloInfinite/PlayerSkillResultValue.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace Grunt.Models.HaloInfinite
+{
+    public class PlayerSkillResultValue
+    {
+        public List<PlayerSkillResult> Value { get; set; }
+    }
+}

--- a/Grunt/Grunt/Models/HaloInfinite/RankRecap.cs
+++ b/Grunt/Grunt/Models/HaloInfinite/RankRecap.cs
@@ -1,0 +1,8 @@
+﻿namespace Grunt.Models.HaloInfinite
+{
+    public class RankRecap
+    {
+        public MatchCsr PreMatchCsr { get; set; }
+        public MatchCsr PostMatchCsr { get; set; }
+    }
+}

--- a/Grunt/Grunt/Models/HaloInfinite/Result.cs
+++ b/Grunt/Grunt/Models/HaloInfinite/Result.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Grunt.Models.HaloInfinite
+{
+    public class Result
+    {
+        public double TeamMmr { get; set; }
+        public RankRecap RankRecap { get; set; }
+        public StatPerformances StatPerformances { get; set; }
+        public int TeamId { get; set; }
+        public Dictionary<String, Double> TeamMmrs { get; set; }
+        public string RankedRewards { get; set; }
+        public Counterfactuals Counterfactuals { get; set; }
+
+    }
+}

--- a/Grunt/Grunt/Models/HaloInfinite/StatPerformances.cs
+++ b/Grunt/Grunt/Models/HaloInfinite/StatPerformances.cs
@@ -1,0 +1,8 @@
+﻿namespace Grunt.Models.HaloInfinite
+{
+    public class StatPerformances
+    {
+        public PerformanceValue Kills { get; set; }
+        public PerformanceValue Deaths { get; set; }
+    }
+}

--- a/Grunt/Grunt/Models/HaloInfinite/TierCounterfactuals.cs
+++ b/Grunt/Grunt/Models/HaloInfinite/TierCounterfactuals.cs
@@ -1,0 +1,12 @@
+﻿namespace Grunt.Models.HaloInfinite
+{
+    public class TierCounterfactuals
+    {
+        public KillDeathStats Bronze { get; set; }
+        public KillDeathStats Silver { get; set; }
+        public KillDeathStats Gold { get; set; }
+        public KillDeathStats Platinum { get; set; }
+        public KillDeathStats Diamond { get; set; }
+        public KillDeathStats Onyx { get; set; }
+    }
+}


### PR DESCRIPTION
Created a few classes to facilitate grabbing the info from skill (ranked) matches, as well as the corresponding method.  Giving it the player id and match id will return ranked related stats for the given player and match, such as Pre/Post CSR, and expected kill/death count.

Feel free to change the naming scheme, I tried to match what you already created.